### PR TITLE
Write-Host: remote sessions support

### DIFF
--- a/Write-Host.ps1
+++ b/Write-Host.ps1
@@ -57,25 +57,19 @@ function Write-Host {
     Process {
         # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_special_characters#escape-e
         # https://docs.microsoft.com/en-us/powershell/scripting/windows-powershell/wmf/whats-new/console-improvements#vt100-support
-        if ($Host.UI.SupportsVirtualTerminal) {
-            $Method = if ($NoNewline) { 'Write' } else { 'WriteLine' }
-            $Output = if ($Separator) { $Object -join $Separator } else { "$Object" }
+        $Output = if ($Separator) { $Object -join $Separator } else { "$Object" }
 
-            # Splitting by regex ensures that this will work on files from Windows/Linux/macOS
-            # Get-Content .\Foobar.txt -Raw | Write-Host -ForegroundColor Red
-            foreach ($item in $Output -split '\r\n|\r|\n') {
-                if ("$BackgroundColor") {
-                    $item = $AnsiTemplate -f ($AnsiColor[$BackgroundColor.value__] + 10), $item, 49
-                }
-                if ("$ForegroundColor") {
-                    $item = $AnsiTemplate -f $AnsiColor[$ForegroundColor.value__], $item, 39
-                }
-
-                [System.Console]::$Method($item)
+        # Splitting by regex ensures that this will work on files from Windows/Linux/macOS
+        # Get-Content .\Foobar.txt -Raw | Write-Host -ForegroundColor Red
+        foreach ($item in $Output -split '\r\n|\r|\n') {
+            if ("$BackgroundColor") {
+                $item = $AnsiTemplate -f ($AnsiColor[$BackgroundColor.value__] + 10), $item, 49
             }
-        }
-        else {
-            Microsoft.PowerShell.Utility\Write-Host @PSBoundParameters
+            if ("$ForegroundColor") {
+                $item = $AnsiTemplate -f $AnsiColor[$ForegroundColor.value__], $item, 39
+            }
+
+            if ($NoNewLine) { Microsoft.PowerShell.Utility\Write-Host -NoNewLine $item } else { Microsoft.PowerShell.Utility\Write-Host $item }
         }
     }
 }


### PR DESCRIPTION
As mentioned in #5, using `System.Console.Write(Line)` functions doesn't work from inside remote sessions. Using the base `Write-Host` here is just simpler and should work in all situations.